### PR TITLE
npm watchオプションの削除

### DIFF
--- a/Runtime/WebGLHelper.cs
+++ b/Runtime/WebGLHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_WEBGL && !UNITY_EDITOR
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Json;
@@ -62,3 +63,4 @@ namespace Extreal.Integration.Web.Common
         public bool IsDebug { get; set; }
     }
 }
+#endif

--- a/WebScripts~/README.md
+++ b/WebScripts~/README.md
@@ -8,6 +8,6 @@ This package is a feature provided by [Extreal](https://fintan.jp/page/6717/), a
 - Run the following commands.
   ```
   $ yarn
-  $ yarn prod
+  $ yarn dev
   $ npm publish --access public
   ```

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "scripts": {
-    "dev": "rollup --config rollup.config.ts --configPlugin typescript --watch",
+    "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
# 何の変更を加えましたか？
- WebGL以外のプラットフォームで発生するエラー対応のため、WebGLでのみ使用するコードにプリプロセッサを追加しました
- 実行時の動作が確認しやすくするためMinify化されないように設定を変更しました
- yarn devコマンド実行時に待たされないように --watchオプションを削除しました
# 何を確認しましたか?

## 実装
- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト
- プリプロセッサ追加のみ修正のため以下はスキップ
- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響
- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました