### PR TITLE
指定した関数呼び出しとコールバックのトレースログを抑制できるように変更

### DIFF
--- a/Samples~/MVS/TestScreen/Sample.cs
+++ b/Samples~/MVS/TestScreen/Sample.cs
@@ -27,6 +27,9 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         public string DoFunction(string param1, string param2)
             => WebGLHelper.CallFunction(nameof(DoFunction), param1, param2);
 
+        public void DoTraceLogSuppressedAction(string param1, string param2)
+            => WebGLHelper.CallAction(nameof(DoTraceLogSuppressedAction), param1, param2);
+
         public string DoTraceLogSuppressedFunction(string param1, string param2)
             => WebGLHelper.CallFunction(nameof(DoTraceLogSuppressedFunction), param1, param2);
 

--- a/Samples~/MVS/TestScreen/Sample.cs
+++ b/Samples~/MVS/TestScreen/Sample.cs
@@ -27,8 +27,8 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         public string DoFunction(string param1, string param2)
             => WebGLHelper.CallFunction(nameof(DoFunction), param1, param2);
 
-        public void SuppressDoActionTraceLog()
-            => WebGLHelper.CallAction(nameof(SuppressDoActionTraceLog));
+        public void SuppressDoFunctionTraceLog()
+            => WebGLHelper.CallAction(nameof(SuppressDoFunctionTraceLog));
 
         protected override void ReleaseManagedResources() => onCallback.Dispose();
     }

--- a/Samples~/MVS/TestScreen/Sample.cs
+++ b/Samples~/MVS/TestScreen/Sample.cs
@@ -27,6 +27,9 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         public string DoFunction(string param1, string param2)
             => WebGLHelper.CallFunction(nameof(DoFunction), param1, param2);
 
+        public void SuppressDoActionTraceLog()
+            => WebGLHelper.CallAction(nameof(SuppressDoActionTraceLog));
+
         protected override void ReleaseManagedResources() => onCallback.Dispose();
     }
 }

--- a/Samples~/MVS/TestScreen/Sample.cs
+++ b/Samples~/MVS/TestScreen/Sample.cs
@@ -27,8 +27,8 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         public string DoFunction(string param1, string param2)
             => WebGLHelper.CallFunction(nameof(DoFunction), param1, param2);
 
-        public void SuppressDoFunctionTraceLog()
-            => WebGLHelper.CallAction(nameof(SuppressDoFunctionTraceLog));
+        public string DoTraceLogSuppressedFunction(string param1, string param2)
+            => WebGLHelper.CallFunction(nameof(DoTraceLogSuppressedFunction), param1, param2);
 
         protected override void ReleaseManagedResources() => onCallback.Dispose();
     }

--- a/Samples~/MVS/TestScreen/TestScreen.unity
+++ b/Samples~/MVS/TestScreen/TestScreen.unity
@@ -450,6 +450,278 @@ MonoBehaviour:
   actionButton: {fileID: 1519889867}
   functionButton: {fileID: 664819600}
   resultText: {fileID: 1568501311}
+  suppressDoActionTraceLogButton: {fileID: 956778936}
+--- !u!1 &799937339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 799937340}
+  - component: {fileID: 799937342}
+  - component: {fileID: 799937341}
+  m_Layer: 5
+  m_Name: SuppressTraceLogDescription
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &799937340
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 799937339}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1062719706}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -160, y: -530}
+  m_SizeDelta: {x: 1150, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &799937341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 799937339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: When the Suppress Action trace log button is pressed, the console trace
+    log for call action is suppressed.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &799937342
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 799937339}
+  m_CullTransparentMesh: 1
+--- !u!1 &846260644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 846260645}
+  - component: {fileID: 846260647}
+  - component: {fileID: 846260646}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &846260645
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846260644}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 956778935}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &846260646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846260644}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Suppress Action trace log
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &846260647
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846260644}
+  m_CullTransparentMesh: 1
 --- !u!1 &877170926
 GameObject:
   m_ObjectHideFlags: 0
@@ -503,6 +775,128 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &956778934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 956778935}
+  - component: {fileID: 956778938}
+  - component: {fileID: 956778937}
+  - component: {fileID: 956778936}
+  m_Layer: 5
+  m_Name: SuppressActionTraceLogButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &956778935
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956778934}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 846260645}
+  m_Father: {fileID: 1062719706}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 500, y: -550}
+  m_SizeDelta: {x: 400, y: 60}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &956778936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956778934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 956778937}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &956778937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956778934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &956778938
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956778934}
+  m_CullTransparentMesh: 1
 --- !u!1 &1031443364
 GameObject:
   m_ObjectHideFlags: 0
@@ -674,6 +1068,8 @@ RectTransform:
   - {fileID: 1519889866}
   - {fileID: 664819599}
   - {fileID: 1568501310}
+  - {fileID: 799937340}
+  - {fileID: 956778935}
   m_Father: {fileID: 1270893444}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Samples~/MVS/TestScreen/TestScreen.unity
+++ b/Samples~/MVS/TestScreen/TestScreen.unity
@@ -156,7 +156,6 @@ RectTransform:
   m_Children:
   - {fileID: 1313255153}
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -277,7 +276,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1466894146}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -425,13 +423,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 792607924}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &792607926
 MonoBehaviour:
@@ -449,8 +447,8 @@ MonoBehaviour:
   param2InputField: {fileID: 1926641159}
   actionButton: {fileID: 1519889867}
   functionButton: {fileID: 664819600}
+  traceLogSuppressedFunctionButton: {fileID: 956778936}
   resultText: {fileID: 1568501311}
-  suppressDoFunctionTraceLogButton: {fileID: 956778936}
 --- !u!1 &799937339
 GameObject:
   m_ObjectHideFlags: 0
@@ -463,7 +461,7 @@ GameObject:
   - component: {fileID: 799937342}
   - component: {fileID: 799937341}
   m_Layer: 5
-  m_Name: SuppressTraceLogDescription
+  m_Name: TraceLogSuppressedFunctionDescription
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -482,12 +480,11 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -200, y: -530}
-  m_SizeDelta: {x: 1200, y: 120}
+  m_AnchoredPosition: {x: -250, y: -500}
+  m_SizeDelta: {x: 1200, y: 160}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &799937341
 MonoBehaviour:
@@ -509,8 +506,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: When the Suppress Function trace log button is pressed, the console trace
-    log for call function is suppressed.
+  m_text: When the Trace Log Suppressed Function button is pressed, the Function
+    is called and the result is displayed but trace log doesn't appear in console.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -618,7 +615,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 956778935}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -645,7 +641,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Suppress Function trace log
+  m_text: Trace Log Suppressed Function
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -754,7 +750,6 @@ RectTransform:
   - {fileID: 2029372622}
   - {fileID: 2147000295}
   m_Father: {fileID: 1398184524}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -788,7 +783,7 @@ GameObject:
   - component: {fileID: 956778937}
   - component: {fileID: 956778936}
   m_Layer: 5
-  m_Name: SuppressFunctionTraceLogButton
+  m_Name: TraceLogSuppressedFunctionButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -808,12 +803,11 @@ RectTransform:
   m_Children:
   - {fileID: 846260645}
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 450, y: -550}
-  m_SizeDelta: {x: 450, y: 60}
+  m_AnchoredPosition: {x: 400, y: -520}
+  m_SizeDelta: {x: 500, y: 60}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &956778936
 MonoBehaviour:
@@ -928,7 +922,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1466894146}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1071,7 +1064,6 @@ RectTransform:
   - {fileID: 799937340}
   - {fileID: 956778935}
   m_Father: {fileID: 1270893444}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1140,13 +1132,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1071534302}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1071534304
 MonoBehaviour:
@@ -1196,7 +1188,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1519889866}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1331,7 +1322,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1536,7 +1526,6 @@ RectTransform:
   m_Children:
   - {fileID: 1062719706}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1574,7 +1563,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 664819599}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1711,7 +1699,6 @@ RectTransform:
   m_Children:
   - {fileID: 877170927}
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1886,7 +1873,6 @@ RectTransform:
   - {fileID: 740629788}
   - {fileID: 1031443365}
   m_Father: {fileID: 1926641158}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1940,7 +1926,6 @@ RectTransform:
   m_Children:
   - {fileID: 1088524824}
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2060,7 +2045,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2197,7 +2181,6 @@ RectTransform:
   m_Children:
   - {fileID: 1466894146}
   m_Father: {fileID: 1062719706}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2372,7 +2355,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 877170927}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2527,7 +2509,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 877170927}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2631,3 +2612,10 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2147000294}
   m_CullTransparentMesh: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1071534303}
+  - {fileID: 792607925}
+  - {fileID: 1270893444}

--- a/Samples~/MVS/TestScreen/TestScreen.unity
+++ b/Samples~/MVS/TestScreen/TestScreen.unity
@@ -450,7 +450,7 @@ MonoBehaviour:
   actionButton: {fileID: 1519889867}
   functionButton: {fileID: 664819600}
   resultText: {fileID: 1568501311}
-  suppressDoActionTraceLogButton: {fileID: 956778936}
+  suppressDoFunctionTraceLogButton: {fileID: 956778936}
 --- !u!1 &799937339
 GameObject:
   m_ObjectHideFlags: 0
@@ -486,8 +486,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -160, y: -530}
-  m_SizeDelta: {x: 1150, y: 120}
+  m_AnchoredPosition: {x: -200, y: -530}
+  m_SizeDelta: {x: 1200, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &799937341
 MonoBehaviour:
@@ -509,8 +509,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: When the Suppress Action trace log button is pressed, the console trace
-    log for call action is suppressed.
+  m_text: When the Suppress Function trace log button is pressed, the console trace
+    log for call function is suppressed.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -645,7 +645,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Suppress Action trace log
+  m_text: Suppress Function trace log
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -788,7 +788,7 @@ GameObject:
   - component: {fileID: 956778937}
   - component: {fileID: 956778936}
   m_Layer: 5
-  m_Name: SuppressActionTraceLogButton
+  m_Name: SuppressFunctionTraceLogButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -812,8 +812,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 500, y: -550}
-  m_SizeDelta: {x: 400, y: 60}
+  m_AnchoredPosition: {x: 450, y: -550}
+  m_SizeDelta: {x: 450, y: 60}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &956778936
 MonoBehaviour:

--- a/Samples~/MVS/TestScreen/TestScreen.unity
+++ b/Samples~/MVS/TestScreen/TestScreen.unity
@@ -123,6 +123,140 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &91566220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 91566221}
+  - component: {fileID: 91566223}
+  - component: {fileID: 91566222}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &91566221
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 91566220}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1056478926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &91566222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 91566220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Trace Log Suppressed Function
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &91566223
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 91566220}
+  m_CullTransparentMesh: 1
 --- !u!1 &664819598
 GameObject:
   m_ObjectHideFlags: 0
@@ -447,7 +581,8 @@ MonoBehaviour:
   param2InputField: {fileID: 1926641159}
   actionButton: {fileID: 1519889867}
   functionButton: {fileID: 664819600}
-  traceLogSuppressedFunctionButton: {fileID: 956778936}
+  traceLogSuppressedActionButton: {fileID: 956778936}
+  traceLogSuppressedFunctionButton: {fileID: 1056478927}
   resultText: {fileID: 1568501311}
 --- !u!1 &799937339
 GameObject:
@@ -461,7 +596,7 @@ GameObject:
   - component: {fileID: 799937342}
   - component: {fileID: 799937341}
   m_Layer: 5
-  m_Name: TraceLogSuppressedFunctionDescription
+  m_Name: TraceLogSuppressedButtonDescription
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -506,8 +641,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: When the Trace Log Suppressed Function button is pressed, the Function
-    is called and the result is displayed but trace log doesn't appear in console.
+  m_text: When the Trace Log Suppressed Action/Function button is pressed, it has
+    the same behavior as the Action/Function button, but the trace log is not displayed
+    in the console.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -534,8 +670,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
+  m_fontSize: 35
+  m_fontSizeBase: 35
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -641,7 +777,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Trace Log Suppressed Function
+  m_text: Trace Log Suppressed Action
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -783,7 +919,7 @@ GameObject:
   - component: {fileID: 956778937}
   - component: {fileID: 956778936}
   m_Layer: 5
-  m_Name: TraceLogSuppressedFunctionButton
+  m_Name: TraceLogSuppressedActionButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -806,7 +942,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 400, y: -520}
+  m_AnchoredPosition: {x: 400, y: -480}
   m_SizeDelta: {x: 500, y: 60}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &956778936
@@ -1025,6 +1161,127 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1031443364}
   m_CullTransparentMesh: 1
+--- !u!1 &1056478925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1056478926}
+  - component: {fileID: 1056478929}
+  - component: {fileID: 1056478928}
+  - component: {fileID: 1056478927}
+  m_Layer: 5
+  m_Name: TraceLogSuppressedFunctionButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1056478926
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056478925}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 91566221}
+  m_Father: {fileID: 1062719706}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 400, y: -560}
+  m_SizeDelta: {x: 500, y: 60}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1056478927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056478925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1056478928}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1056478928
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056478925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1056478929
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056478925}
+  m_CullTransparentMesh: 1
 --- !u!1 &1062719705
 GameObject:
   m_ObjectHideFlags: 0
@@ -1063,6 +1320,7 @@ RectTransform:
   - {fileID: 1568501310}
   - {fileID: 799937340}
   - {fileID: 956778935}
+  - {fileID: 1056478926}
   m_Father: {fileID: 1270893444}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Samples~/MVS/TestScreen/TestScreenPresenter.cs
+++ b/Samples~/MVS/TestScreen/TestScreenPresenter.cs
@@ -33,6 +33,10 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
             sample.OnCallback
                 .Subscribe(testScreenView.ShowResult)
                 .AddTo(disposables);
+
+            testScreenView.OnSuppressDoActionTraceLogButtonClicked
+                .Subscribe(_ => sample.SuppressDoActionTraceLog())
+                .AddTo(disposables);
         }
 
         protected override void ReleaseManagedResources() => disposables.Dispose();

--- a/Samples~/MVS/TestScreen/TestScreenPresenter.cs
+++ b/Samples~/MVS/TestScreen/TestScreenPresenter.cs
@@ -30,8 +30,8 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 })
                 .AddTo(disposables);
 
-            sample.OnCallback
-                .Subscribe(testScreenView.ShowResult)
+            testScreenView.OnTraceLogSuppressedActionButtonClicked
+                .Subscribe(parameters => sample.DoTraceLogSuppressedAction(parameters.Param1, parameters.Param2))
                 .AddTo(disposables);
 
             testScreenView.OnTraceLogSuppressedFunctionButtonClicked
@@ -40,6 +40,10 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                     var result = sample.DoTraceLogSuppressedFunction(parameters.Param1, parameters.Param2);
                     testScreenView.ShowResult(result);
                 })
+                .AddTo(disposables);
+
+            sample.OnCallback
+                .Subscribe(testScreenView.ShowResult)
                 .AddTo(disposables);
         }
 

--- a/Samples~/MVS/TestScreen/TestScreenPresenter.cs
+++ b/Samples~/MVS/TestScreen/TestScreenPresenter.cs
@@ -34,8 +34,12 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .Subscribe(testScreenView.ShowResult)
                 .AddTo(disposables);
 
-            testScreenView.OnSuppressDoFunctionTraceLogButtonClicked
-                .Subscribe(_ => sample.SuppressDoFunctionTraceLog())
+            testScreenView.OnTraceLogSuppressedFunctionButtonClicked
+                .Subscribe(parameters =>
+                {
+                    var result = sample.DoTraceLogSuppressedFunction(parameters.Param1, parameters.Param2);
+                    testScreenView.ShowResult(result);
+                })
                 .AddTo(disposables);
         }
 

--- a/Samples~/MVS/TestScreen/TestScreenPresenter.cs
+++ b/Samples~/MVS/TestScreen/TestScreenPresenter.cs
@@ -34,8 +34,8 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .Subscribe(testScreenView.ShowResult)
                 .AddTo(disposables);
 
-            testScreenView.OnSuppressDoActionTraceLogButtonClicked
-                .Subscribe(_ => sample.SuppressDoActionTraceLog())
+            testScreenView.OnSuppressDoFunctionTraceLogButtonClicked
+                .Subscribe(_ => sample.SuppressDoFunctionTraceLog())
                 .AddTo(disposables);
         }
 

--- a/Samples~/MVS/TestScreen/TestScreenView.cs
+++ b/Samples~/MVS/TestScreen/TestScreenView.cs
@@ -14,6 +14,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SerializeField] private Button actionButton;
         [SerializeField] private Button functionButton;
         [SerializeField] private TMP_Text resultText;
+        [SerializeField] private Button suppressDoActionTraceLogButton;
 
         public class Parameters
         {
@@ -35,6 +36,10 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SuppressMessage("CodeCracker", "CC0033")]
         private readonly Subject<Parameters> onFunctionButtonClicked = new Subject<Parameters>();
 
+        public IObservable<Unit> OnSuppressDoActionTraceLogButtonClicked => onSuppressDoActionTraceLogButtonClicked;
+        [SuppressMessage("CodeCracker", "CC0033")]
+        private readonly Subject<Unit> onSuppressDoActionTraceLogButtonClicked = new Subject<Unit>();
+
         [SuppressMessage("CodeCracker", "CC0068")]
         private void Awake()
         {
@@ -47,6 +52,15 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .OnClickAsObservable()
                 .TakeUntilDestroy(this)
                 .Subscribe(_ => onFunctionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
+
+            suppressDoActionTraceLogButton
+                .OnClickAsObservable()
+                .TakeUntilDestroy(this)
+                .Subscribe(_ =>
+                {
+                    suppressDoActionTraceLogButton.interactable = false;
+                    onSuppressDoActionTraceLogButtonClicked.OnNext(Unit.Default);
+                });
         }
 
         [SuppressMessage("CodeCracker", "CC0068")]
@@ -54,6 +68,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         {
             onActionButtonClicked.Dispose();
             onFunctionButtonClicked.Dispose();
+            onSuppressDoActionTraceLogButtonClicked.Dispose();
         }
 
         public void ShowResult(string result) => resultText.text = result;

--- a/Samples~/MVS/TestScreen/TestScreenView.cs
+++ b/Samples~/MVS/TestScreen/TestScreenView.cs
@@ -13,6 +13,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SerializeField] private TMP_InputField param2InputField;
         [SerializeField] private Button actionButton;
         [SerializeField] private Button functionButton;
+        [SerializeField] private Button traceLogSuppressedActionButton;
         [SerializeField] private Button traceLogSuppressedFunctionButton;
         [SerializeField] private TMP_Text resultText;
 
@@ -36,6 +37,10 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SuppressMessage("CodeCracker", "CC0033")]
         private readonly Subject<Parameters> onFunctionButtonClicked = new Subject<Parameters>();
 
+        public IObservable<Parameters> OnTraceLogSuppressedActionButtonClicked => onTraceLogSuppressedActionButtonClicked;
+        [SuppressMessage("CodeCracker", "CC0033")]
+        private readonly Subject<Parameters> onTraceLogSuppressedActionButtonClicked = new Subject<Parameters>();
+
         public IObservable<Parameters> OnTraceLogSuppressedFunctionButtonClicked => onTraceLogSuppressedFunctionButtonClicked;
         [SuppressMessage("CodeCracker", "CC0033")]
         private readonly Subject<Parameters> onTraceLogSuppressedFunctionButtonClicked = new Subject<Parameters>();
@@ -52,6 +57,11 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .OnClickAsObservable()
                 .TakeUntilDestroy(this)
                 .Subscribe(_ => onFunctionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
+
+            traceLogSuppressedActionButton
+                .OnClickAsObservable()
+                .TakeUntilDestroy(this)
+                .Subscribe(_ => onTraceLogSuppressedActionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
 
             traceLogSuppressedFunctionButton
                 .OnClickAsObservable()

--- a/Samples~/MVS/TestScreen/TestScreenView.cs
+++ b/Samples~/MVS/TestScreen/TestScreenView.cs
@@ -14,7 +14,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SerializeField] private Button actionButton;
         [SerializeField] private Button functionButton;
         [SerializeField] private TMP_Text resultText;
-        [SerializeField] private Button suppressDoActionTraceLogButton;
+        [SerializeField] private Button suppressDoFunctionTraceLogButton;
 
         public class Parameters
         {
@@ -36,9 +36,9 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SuppressMessage("CodeCracker", "CC0033")]
         private readonly Subject<Parameters> onFunctionButtonClicked = new Subject<Parameters>();
 
-        public IObservable<Unit> OnSuppressDoActionTraceLogButtonClicked => onSuppressDoActionTraceLogButtonClicked;
+        public IObservable<Unit> OnSuppressDoFunctionTraceLogButtonClicked => onSuppressDoFunctionTraceLogButtonClicked;
         [SuppressMessage("CodeCracker", "CC0033")]
-        private readonly Subject<Unit> onSuppressDoActionTraceLogButtonClicked = new Subject<Unit>();
+        private readonly Subject<Unit> onSuppressDoFunctionTraceLogButtonClicked = new Subject<Unit>();
 
         [SuppressMessage("CodeCracker", "CC0068")]
         private void Awake()
@@ -53,13 +53,13 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .TakeUntilDestroy(this)
                 .Subscribe(_ => onFunctionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
 
-            suppressDoActionTraceLogButton
+            suppressDoFunctionTraceLogButton
                 .OnClickAsObservable()
                 .TakeUntilDestroy(this)
                 .Subscribe(_ =>
                 {
-                    suppressDoActionTraceLogButton.interactable = false;
-                    onSuppressDoActionTraceLogButtonClicked.OnNext(Unit.Default);
+                    suppressDoFunctionTraceLogButton.interactable = false;
+                    onSuppressDoFunctionTraceLogButtonClicked.OnNext(Unit.Default);
                 });
         }
 
@@ -68,7 +68,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         {
             onActionButtonClicked.Dispose();
             onFunctionButtonClicked.Dispose();
-            onSuppressDoActionTraceLogButtonClicked.Dispose();
+            onSuppressDoFunctionTraceLogButtonClicked.Dispose();
         }
 
         public void ShowResult(string result) => resultText.text = result;

--- a/Samples~/MVS/TestScreen/TestScreenView.cs
+++ b/Samples~/MVS/TestScreen/TestScreenView.cs
@@ -13,8 +13,8 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SerializeField] private TMP_InputField param2InputField;
         [SerializeField] private Button actionButton;
         [SerializeField] private Button functionButton;
+        [SerializeField] private Button traceLogSuppressedFunctionButton;
         [SerializeField] private TMP_Text resultText;
-        [SerializeField] private Button suppressDoFunctionTraceLogButton;
 
         public class Parameters
         {
@@ -36,9 +36,9 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         [SuppressMessage("CodeCracker", "CC0033")]
         private readonly Subject<Parameters> onFunctionButtonClicked = new Subject<Parameters>();
 
-        public IObservable<Unit> OnSuppressDoFunctionTraceLogButtonClicked => onSuppressDoFunctionTraceLogButtonClicked;
+        public IObservable<Parameters> OnTraceLogSuppressedFunctionButtonClicked => onTraceLogSuppressedFunctionButtonClicked;
         [SuppressMessage("CodeCracker", "CC0033")]
-        private readonly Subject<Unit> onSuppressDoFunctionTraceLogButtonClicked = new Subject<Unit>();
+        private readonly Subject<Parameters> onTraceLogSuppressedFunctionButtonClicked = new Subject<Parameters>();
 
         [SuppressMessage("CodeCracker", "CC0068")]
         private void Awake()
@@ -53,14 +53,10 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
                 .TakeUntilDestroy(this)
                 .Subscribe(_ => onFunctionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
 
-            suppressDoFunctionTraceLogButton
+            traceLogSuppressedFunctionButton
                 .OnClickAsObservable()
                 .TakeUntilDestroy(this)
-                .Subscribe(_ =>
-                {
-                    suppressDoFunctionTraceLogButton.interactable = false;
-                    onSuppressDoFunctionTraceLogButtonClicked.OnNext(Unit.Default);
-                });
+                .Subscribe(_ => onTraceLogSuppressedFunctionButtonClicked.OnNext(new Parameters(param1InputField.text, param2InputField.text)));
         }
 
         [SuppressMessage("CodeCracker", "CC0068")]
@@ -68,7 +64,7 @@ namespace Extreal.Integration.Web.Common.MVS.TestScreen
         {
             onActionButtonClicked.Dispose();
             onFunctionButtonClicked.Dispose();
-            onSuppressDoFunctionTraceLogButtonClicked.Dispose();
+            onTraceLogSuppressedFunctionButtonClicked.Dispose();
         }
 
         public void ShowResult(string result) => resultText.text = result;

--- a/Samples~/MVS/WebGLScripts~/src/index.ts
+++ b/Samples~/MVS/WebGLScripts~/src/index.ts
@@ -8,6 +8,6 @@ addFunction("DoFunction", (str1, str2) => {
     return `received param1=[${str1}] param2=[${str2}] in function`;
 });
 
-addAction("SuppressDoActionTraceLog", (unused1, unused2) => {
-    suppressTraceLog("DoAction");
+addAction("SuppressDoFunctionTraceLog", (unused1, unused2) => {
+    suppressTraceLog("DoFunction");
 })

--- a/Samples~/MVS/WebGLScripts~/src/index.ts
+++ b/Samples~/MVS/WebGLScripts~/src/index.ts
@@ -1,4 +1,4 @@
-import { callback, addAction, addFunction, suppressTraceLog } from "@extreal-dev/extreal.integration.web.common";
+import { callback, addAction, addFunction } from "@extreal-dev/extreal.integration.web.common";
 
 addAction("DoAction", (str1, str2) => {
     callback("HandleOnCallback", `param1=[${str1}]`, `param2=[${str2}]`);
@@ -8,6 +8,10 @@ addFunction("DoFunction", (str1, str2) => {
     return `received param1=[${str1}] param2=[${str2}] in function`;
 });
 
-addAction("SuppressDoFunctionTraceLog", (unused1, unused2) => {
-    suppressTraceLog("DoFunction");
-})
+addFunction(
+    "DoTraceLogSuppressedFunction",
+    (str1, str2) => {
+        return `received param1=[${str1}] param2=[${str2}] in function`;
+    },
+    true
+);

--- a/Samples~/MVS/WebGLScripts~/src/index.ts
+++ b/Samples~/MVS/WebGLScripts~/src/index.ts
@@ -8,10 +8,15 @@ addFunction("DoFunction", (str1, str2) => {
     return `received param1=[${str1}] param2=[${str2}] in function`;
 });
 
+addAction("DoTraceLogSuppressedAction",
+    (str1, str2) => {
+        callback("HandleOnCallback", `param1=[${str1}]`, `param2=[${str2}]`, true);
+    },
+    true);
+
 addFunction(
     "DoTraceLogSuppressedFunction",
     (str1, str2) => {
         return `received param1=[${str1}] param2=[${str2}] in function`;
     },
-    true
-);
+    true);

--- a/Samples~/MVS/WebGLScripts~/src/index.ts
+++ b/Samples~/MVS/WebGLScripts~/src/index.ts
@@ -1,4 +1,4 @@
-import { callback, addAction, addFunction } from "@extreal-dev/extreal.integration.web.common";
+import { callback, addAction, addFunction, suppressTraceLog } from "@extreal-dev/extreal.integration.web.common";
 
 addAction("DoAction", (str1, str2) => {
     callback("HandleOnCallback", `param1=[${str1}]`, `param2=[${str2}]`);
@@ -7,3 +7,7 @@ addAction("DoAction", (str1, str2) => {
 addFunction("DoFunction", (str1, str2) => {
     return `received param1=[${str1}] param2=[${str2}] in function`;
 });
+
+addAction("SuppressDoActionTraceLog", (unused1, unused2) => {
+    suppressTraceLog("DoAction");
+})

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "1.0.2",
+  "version": "1.1.0-next.0",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"
@@ -30,6 +30,5 @@
     "tslib": "^2.6.0",
     "typescript": "^5.1.6"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "1.1.0-next.0",
+  "version": "1.1.0-next.1",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.web.common",
-  "version": "1.1.0-next.2",
+  "version": "1.1.0-next.3",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/src/helper.ts
+++ b/WebScripts~/src/helper.ts
@@ -125,13 +125,6 @@ bindMethod("AddCallback", (namePtr: Pointer, callbackPtr: Pointer) => {
     });
 });
 
-const suppressTraceLog = (name: string) => {
-    if (isDebug) {
-        console.log(`suppress trace log: name=${name}`);
-    }
-    traceLogSuppressedNames.add(name);
-}
-
 /**
  * Adds a function without a return value.
  * 
@@ -199,5 +192,17 @@ const waitUntil = (condition: () => boolean, cancel: () => boolean, interval = 1
 const isAsync = (func: object) => {
     return typeof func === "function" && Object.prototype.toString.call(func) === "[object AsyncFunction]";
 };
+
+/**
+ * Suppresses trace log for the specified function or callback.
+ * 
+ * @param name - Target
+ */
+const suppressTraceLog = (name: string) => {
+    if (isDebug) {
+        console.log(`suppress trace log: name=${name}`);
+    }
+    traceLogSuppressedNames.add(name);
+}
 
 export { addAction, addFunction, callback, isDebug, waitUntil, isAsync, suppressTraceLog };

--- a/WebScripts~/src/helper.ts
+++ b/WebScripts~/src/helper.ts
@@ -83,6 +83,8 @@ const actions = new Map<string, Action>();
 const functions = new Map<string, Function>();
 const callbacks = new Map<string, Callback>();
 
+const traceLogSuppressedNames = new Set<string>();
+
 const UNUSED = "";
 
 bindMethod("CallAction", (namePtr: Pointer, strParamPtr1: Pointer, strParamPtr2: Pointer) => {
@@ -93,7 +95,7 @@ bindMethod("CallAction", (namePtr: Pointer, strParamPtr1: Pointer, strParamPtr2:
     }
     const strParam1 = strParamPtr1 ? ptrToStr(strParamPtr1) : UNUSED;
     const strParam2 = strParamPtr2 ? ptrToStr(strParamPtr2) : UNUSED;
-    if (isDebug) {
+    if (isDebug && !traceLogSuppressedNames.has(name)) {
         console.log(`call action: name=${name} strParam1=${strParam1} strParam2=${strParam2}`);
     }
     action(strParam1, strParam2);
@@ -107,7 +109,7 @@ bindMethod("CallFunction", (namePtr: Pointer, strParamPtr1: Pointer, strParamPtr
     }
     const strParam1 = strParamPtr1 ? ptrToStr(strParamPtr1) : UNUSED;
     const strParam2 = strParamPtr2 ? ptrToStr(strParamPtr2) : UNUSED;
-    if (isDebug) {
+    if (isDebug && !traceLogSuppressedNames.has(name)) {
         console.log(`call function: name=${name} strParam1=${strParam1} strParam2=${strParam2}`);
     }
     return strToPtr(func(strParam1, strParam2));
@@ -122,6 +124,13 @@ bindMethod("AddCallback", (namePtr: Pointer, callbackPtr: Pointer) => {
         callbackToUnity(callbackPtr, str1, str2);
     });
 });
+
+const suppressTraceLog = (name: string) => {
+    if (isDebug) {
+        console.log(`suppress trace log: name=${name}`);
+    }
+    traceLogSuppressedNames.add(name);
+}
 
 /**
  * Adds a function without a return value.
@@ -155,7 +164,7 @@ const callback = (name: string, strParam1?: string, strParam2?: string) => {
     if (!cb) {
         throw new Error(`A callback to call not found. name=${name}`);
     }
-    if (isDebug) {
+    if (isDebug && !traceLogSuppressedNames.has(name)) {
         console.log(`call callback: name=${name} strParam1=${strParam1} strParam2=${strParam2}`);
     }
     cb(strParam1 ?? UNUSED, strParam2 ?? UNUSED);
@@ -191,4 +200,4 @@ const isAsync = (func: object) => {
     return typeof func === "function" && Object.prototype.toString.call(func) === "[object AsyncFunction]";
 };
 
-export { addAction, addFunction, callback, isDebug, waitUntil, isAsync };
+export { addAction, addFunction, callback, isDebug, waitUntil, isAsync, suppressTraceLog };

--- a/WebScripts~/src/helper.ts
+++ b/WebScripts~/src/helper.ts
@@ -131,8 +131,11 @@ bindMethod("AddCallback", (namePtr: Pointer, callbackPtr: Pointer) => {
  * @param name - Target
  * @param action - Function
  */
-const addAction = (name: string, action: Action) => {
+const addAction = (name: string, action: Action, isSuppressTraceLog: boolean = false) => {
     actions.set(name, action);
+    if (isSuppressTraceLog) {
+        suppressTraceLog(name);
+    }
 };
 
 /**
@@ -141,8 +144,11 @@ const addAction = (name: string, action: Action) => {
  * @param name - Target
  * @param func - Function
  */
-const addFunction = (name: string, func: Function) => {
+const addFunction = (name: string, func: Function, isSuppressTraceLog: boolean = false) => {
     functions.set(name, func);
+    if (isSuppressTraceLog) {
+        suppressTraceLog(name);
+    }
 };
 
 /**
@@ -152,12 +158,12 @@ const addFunction = (name: string, func: Function) => {
  * @param strParam1 - First string parameter
  * @param strParam2 - Second string parameter
  */
-const callback = (name: string, strParam1?: string, strParam2?: string) => {
+const callback = (name: string, strParam1?: string, strParam2?: string, isSuppressTraceLog: boolean = false) => {
     const cb = callbacks.get(name);
     if (!cb) {
         throw new Error(`A callback to call not found. name=${name}`);
     }
-    if (isDebug && !traceLogSuppressedNames.has(name)) {
+    if (isDebug && !isSuppressTraceLog) {
         console.log(`call callback: name=${name} strParam1=${strParam1} strParam2=${strParam2}`);
     }
     cb(strParam1 ?? UNUSED, strParam2 ?? UNUSED);
@@ -193,16 +199,8 @@ const isAsync = (func: object) => {
     return typeof func === "function" && Object.prototype.toString.call(func) === "[object AsyncFunction]";
 };
 
-/**
- * Suppresses trace log for the specified function or callback.
- * 
- * @param name - Target
- */
 const suppressTraceLog = (name: string) => {
-    if (isDebug) {
-        console.log(`suppress trace log: name=${name}`);
-    }
     traceLogSuppressedNames.add(name);
 }
 
-export { addAction, addFunction, callback, isDebug, waitUntil, isAsync, suppressTraceLog };
+export { addAction, addFunction, callback, isDebug, waitUntil, isAsync };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.web.common",
-  "version": "1.1.0-next.0",
+  "version": "1.1.0-next.1",
   "displayName": "Extreal.Integration.Web.Common",
   "unity": "2022.3",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.web.common",
-  "version": "1.0.0",
+  "version": "1.1.0-next.0",
   "displayName": "Extreal.Integration.Web.Common",
   "unity": "2022.3",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.web.common",
-  "version": "1.1.0-next.2",
+  "version": "1.1.0-next.3",
   "displayName": "Extreal.Integration.Web.Common",
   "unity": "2022.3",
   "author": {


### PR DESCRIPTION
# 何の変更を加えましたか？
- addAction/addFunction/callbackで指定したターゲット名を使用して、特定のトレースログを抑制できるように変更しました。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
  - 自動テストなし
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
  - 変更なし
- [x] Sample Applicationに変更が反映されることを確認しました
  - 変更なし

# レビュアーへのメッセージ
- [ガイドのPR](https://github.com/extreal-dev/Extreal.Guide/pull/60)